### PR TITLE
Updating to Swift 3

### DIFF
--- a/MyPlayground.playground/Contents.swift
+++ b/MyPlayground.playground/Contents.swift
@@ -22,18 +22,18 @@ public class Serializable: NSObject
             if let values = i.value as? NSArray {
                 var serializedChildren = [[String:AnyObject]]()
                 for item in values {
-                    serializedChildren.append(item.serialize())
+                    serializedChildren.append((item as AnyObject).serialize())
                 }
                 
-                transfer[i.label!] = serializedChildren
+                transfer[i.label!] = serializedChildren as AnyObject?
             }
                 // If this is a serializable object, serialize it
             else if let value = i.value as? Serializable {
-                transfer[i.label!] = value.serialize()
+                transfer[i.label!] = value.serialize() as AnyObject?
             }
                 // Otherwise, serialize the property as long as it is not nil
-            else if let value = i.value as? AnyObject {
-                transfer[i.label!] = value
+            else {
+                transfer[i.label!] = i.value as AnyObject
             }
         }
         
@@ -56,22 +56,23 @@ public class Serializable: NSObject
     public static func deserialize<T: Serializable>(transfer: [String:AnyObject]) -> T {
         let target = T()
         
-        let dateFormatter = NSDateFormatter()
+        let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SS"
         
-        let dateFormatter2 = NSDateFormatter()
+        let dateFormatter2 = DateFormatter()
         dateFormatter2.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
         
         for item in transfer {
             if let values = item.1 as? NSArray {
                 var children = [Serializable]()
                 
-                var parameterTypeString = target.getTypeOfVariableWithName(item.0)
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.lessThanString).last
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.greaterThanString).first
+                var parameterTypeString = target.getTypeOfVariableWithName(name: item.0)
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).last
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).first
                 
-                let extensionParameterTypeStringArray = parameterTypeString?.componentsSeparatedByString(Serializable.periodString)
-                if extensionParameterTypeStringArray?.count > 1 {
+                
+                let extensionParameterTypeStringArray = parameterTypeString?.components(separatedBy: Serializable.periodString)
+                if (extensionParameterTypeStringArray?.count)! > 1 {
                     parameterTypeString = extensionParameterTypeStringArray?.last
                 }
                 
@@ -79,33 +80,33 @@ public class Serializable: NSObject
                 
                 for value in values {
                     let child: Serializable = (nsobjectype.init() as? Serializable)!
-                    child.deserialize(value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
+                    child.deserialize(transfer: value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
                     children.append(child)
                 }
                 
                 target.setValue(children, forKey: item.0)
             } else if let _ = item.1 as? NSDictionary {
                 
-                var parameterTypeString = target.getTypeOfVariableWithName(item.0)
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.lessThanString).last
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.greaterThanString).first
+                var parameterTypeString = target.getTypeOfVariableWithName(name: item.0)
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).last
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).first
                 
-                let extensionParameterTypeStringArray = parameterTypeString?.componentsSeparatedByString(Serializable.periodString)
-                if extensionParameterTypeStringArray?.count > 1 {
+                let extensionParameterTypeStringArray = parameterTypeString?.components(separatedBy: Serializable.periodString)
+                if (extensionParameterTypeStringArray?.count)! > 1 {
                     parameterTypeString = extensionParameterTypeStringArray?.last
                 }
                 
                 let nsobjectype : NSObject.Type = NSClassFromString(parameterTypeString!) as! NSObject.Type
                 
                 let child: Serializable = (nsobjectype.init() as? Serializable)!
-                child.deserialize(item.1 as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
+                child.deserialize(transfer: item.1 as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
                 
                 target.setValue(child, forKey: item.0)
             } else {
                 if let stringValue = item.1 as? String {
-                    if let date = dateFormatter.dateFromString(stringValue) {
+                    if let date = dateFormatter.date(from: stringValue) {
                         target.setValue(date, forKey: item.0)
-                    } else if let date = dateFormatter2.dateFromString(stringValue) {
+                    } else if let date = dateFormatter2.date(from: stringValue) {
                         target.setValue(date, forKey: item.0)
                     } else {
                         target.setValue(item.1, forKey: item.0)
@@ -119,18 +120,18 @@ public class Serializable: NSObject
         return target
     }
     
-    public func deserialize(transfer: [String:AnyObject], dateFormatter: NSDateFormatter, dateFormatter2: NSDateFormatter) {
+    public func deserialize(transfer: [String:AnyObject], dateFormatter: DateFormatter, dateFormatter2: DateFormatter) {
         
         for item in transfer {
             if let values = item.1 as? NSArray {
                 var children = [Serializable]()
                 
-                var parameterTypeString = self.getTypeOfVariableWithName(item.0)
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.lessThanString).last
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.greaterThanString).first
+                var parameterTypeString = self.getTypeOfVariableWithName(name: item.0)
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).last
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).first
                 
-                let extensionParameterTypeStringArray = parameterTypeString?.componentsSeparatedByString(Serializable.periodString)
-                if extensionParameterTypeStringArray?.count > 1 {
+                let extensionParameterTypeStringArray = parameterTypeString?.components(separatedBy: Serializable.periodString)
+                if (extensionParameterTypeStringArray?.count)! > 1 {
                     parameterTypeString = extensionParameterTypeStringArray?.last
                 }
                 
@@ -138,16 +139,16 @@ public class Serializable: NSObject
                 
                 for value in values {
                     let child: Serializable = (nsobjectype.init() as? Serializable)!
-                    child.deserialize(value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
+                    child.deserialize(transfer: value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
                     children.append(child)
                 }
                 
                 self.setValue(children, forKey: item.0)
             } else {
                 if let stringValue = item.1 as? String {
-                    if let date = dateFormatter.dateFromString(stringValue) {
+                    if let date = dateFormatter.date(from: stringValue) {
                         self.setValue(date, forKey: item.0)
-                    } else if let  date = dateFormatter2.dateFromString(stringValue) {
+                    } else if let  date = dateFormatter2.date(from: stringValue) {
                         self.setValue(date, forKey: item.0)
                     } else {
                         self.setValue(item.1, forKey: item.0)
@@ -161,11 +162,10 @@ public class Serializable: NSObject
     
     func getTypeOfVariableWithName(name: String) -> String! {
         let mirror = Mirror(reflecting: self)
-        mirror.subjectType
         for i in mirror.children
         {
             if i.label == name {
-                let longName = String(i.value.dynamicType)
+                let longName = String(describing: type(of: i.value))
                 return longName
             }
         }

--- a/Serializable.swift
+++ b/Serializable.swift
@@ -28,18 +28,18 @@ public class Serializable: NSObject
             if let values = i.value as? NSArray {
                 var serializedChildren = [[String:AnyObject]]()
                 for item in values {
-                    serializedChildren.append(item.serialize())
+                    serializedChildren.append((item as AnyObject).serialize())
                 }
                 
-                transfer[i.label!] = serializedChildren
+                transfer[i.label!] = serializedChildren as AnyObject?
             }
                 // If this is a serializable object, serialize it
             else if let value = i.value as? Serializable {
-                transfer[i.label!] = value.serialize()
+                transfer[i.label!] = value.serialize() as AnyObject?
             }
                 // Otherwise, serialize the property as long as it is not nil
-            else if let value = i.value as? AnyObject {
-                transfer[i.label!] = value
+            else {
+                transfer[i.label!] = i.value as AnyObject
             }
         }
         
@@ -62,22 +62,23 @@ public class Serializable: NSObject
     public static func deserialize<T: Serializable>(transfer: [String:AnyObject]) -> T {
         let target = T()
         
-        let dateFormatter = NSDateFormatter()
+        let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SS"
         
-        let dateFormatter2 = NSDateFormatter()
+        let dateFormatter2 = DateFormatter()
         dateFormatter2.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ"
         
         for item in transfer {
             if let values = item.1 as? NSArray {
                 var children = [Serializable]()
                 
-                var parameterTypeString = target.getTypeOfVariableWithName(item.0)
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.lessThanString).last
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.greaterThanString).first
+                var parameterTypeString = target.getTypeOfVariableWithName(name: item.0)
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).last
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).first
                 
-                let extensionParameterTypeStringArray = parameterTypeString?.componentsSeparatedByString(Serializable.periodString)
-                if extensionParameterTypeStringArray?.count > 1 {
+                
+                let extensionParameterTypeStringArray = parameterTypeString?.components(separatedBy: Serializable.periodString)
+                if (extensionParameterTypeStringArray?.count)! > 1 {
                     parameterTypeString = extensionParameterTypeStringArray?.last
                 }
                 
@@ -85,33 +86,33 @@ public class Serializable: NSObject
                 
                 for value in values {
                     let child: Serializable = (nsobjectype.init() as? Serializable)!
-                    child.deserialize(value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
+                    child.deserialize(transfer: value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
                     children.append(child)
                 }
                 
                 target.setValue(children, forKey: item.0)
             } else if let _ = item.1 as? NSDictionary {
                 
-                var parameterTypeString = target.getTypeOfVariableWithName(item.0)
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.lessThanString).last
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.greaterThanString).first
+                var parameterTypeString = target.getTypeOfVariableWithName(name: item.0)
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).last
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).first
                 
-                let extensionParameterTypeStringArray = parameterTypeString?.componentsSeparatedByString(Serializable.periodString)
-                if extensionParameterTypeStringArray?.count > 1 {
+                let extensionParameterTypeStringArray = parameterTypeString?.components(separatedBy: Serializable.periodString)
+                if (extensionParameterTypeStringArray?.count)! > 1 {
                     parameterTypeString = extensionParameterTypeStringArray?.last
                 }
                 
                 let nsobjectype : NSObject.Type = NSClassFromString(parameterTypeString!) as! NSObject.Type
                 
                 let child: Serializable = (nsobjectype.init() as? Serializable)!
-                child.deserialize(item.1 as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
+                child.deserialize(transfer: item.1 as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
                 
                 target.setValue(child, forKey: item.0)
             } else {
                 if let stringValue = item.1 as? String {
-                    if let date = dateFormatter.dateFromString(stringValue) {
+                    if let date = dateFormatter.date(from: stringValue) {
                         target.setValue(date, forKey: item.0)
-                    } else if let date = dateFormatter2.dateFromString(stringValue) {
+                    } else if let date = dateFormatter2.date(from: stringValue) {
                         target.setValue(date, forKey: item.0)
                     } else {
                         target.setValue(item.1, forKey: item.0)
@@ -125,18 +126,18 @@ public class Serializable: NSObject
         return target
     }
     
-    public func deserialize(transfer: [String:AnyObject], dateFormatter: NSDateFormatter, dateFormatter2: NSDateFormatter) {
+    public func deserialize(transfer: [String:AnyObject], dateFormatter: DateFormatter, dateFormatter2: DateFormatter) {
         
         for item in transfer {
             if let values = item.1 as? NSArray {
                 var children = [Serializable]()
                 
-                var parameterTypeString = self.getTypeOfVariableWithName(item.0)
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.lessThanString).last
-                parameterTypeString = parameterTypeString?.componentsSeparatedByString(Serializable.greaterThanString).first
+                var parameterTypeString = self.getTypeOfVariableWithName(name: item.0)
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).last
+                parameterTypeString = parameterTypeString?.components(separatedBy: Serializable.greaterThanString).first
                 
-                let extensionParameterTypeStringArray = parameterTypeString?.componentsSeparatedByString(Serializable.periodString)
-                if extensionParameterTypeStringArray?.count > 1 {
+                let extensionParameterTypeStringArray = parameterTypeString?.components(separatedBy: Serializable.periodString)
+                if (extensionParameterTypeStringArray?.count)! > 1 {
                     parameterTypeString = extensionParameterTypeStringArray?.last
                 }
                 
@@ -144,16 +145,16 @@ public class Serializable: NSObject
                 
                 for value in values {
                     let child: Serializable = (nsobjectype.init() as? Serializable)!
-                    child.deserialize(value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
+                    child.deserialize(transfer: value as! [String : AnyObject], dateFormatter: dateFormatter, dateFormatter2: dateFormatter2)
                     children.append(child)
                 }
                 
                 self.setValue(children, forKey: item.0)
             } else {
                 if let stringValue = item.1 as? String {
-                    if let date = dateFormatter.dateFromString(stringValue) {
+                    if let date = dateFormatter.date(from: stringValue) {
                         self.setValue(date, forKey: item.0)
-                    } else if let  date = dateFormatter2.dateFromString(stringValue) {
+                    } else if let  date = dateFormatter2.date(from: stringValue) {
                         self.setValue(date, forKey: item.0)
                     } else {
                         self.setValue(item.1, forKey: item.0)
@@ -167,11 +168,10 @@ public class Serializable: NSObject
     
     func getTypeOfVariableWithName(name: String) -> String! {
         let mirror = Mirror(reflecting: self)
-        mirror.subjectType
         for i in mirror.children
         {
             if i.label == name {
-                let longName = String(i.value.dynamicType)
+                let longName = String(describing: type(of: i.value))
                 return longName
             }
         }


### PR DESCRIPTION
A few of the APIs have some changes, specifically in regards to parameter naming. Complies with Swift version 3.
